### PR TITLE
exampleのmnits, cifar10のコードを修正しました．

### DIFF
--- a/examples/cifar10/allconvnet.py
+++ b/examples/cifar10/allconvnet.py
@@ -22,15 +22,14 @@ class AllConvNet(chainer.Chain):
                 conv8 = L.Convolution2D(192, 192, 1),
                 conv9 = L.Convolution2D(192, 10, 1),
         )
-        self.train = True
 
-    def __call__(self, x):
-        h = F.relu(self.conv1(F.dropout(x, ratio=0.2, train=self.train)))
+    def __call__(self, x, t=None, train=True):
+        h = F.relu(self.conv1(F.dropout(x, ratio=0.2, train=train)))
         h = F.relu(self.conv2(h))
-        h = F.dropout(F.relu(self.conv3(h)), ratio=0.5, train=self.train)
+        h = F.dropout(F.relu(self.conv3(h)), ratio=0.5, train=train)
         h = F.relu(self.conv4(h))
         h = F.relu(self.conv5(h))
-        h = F.dropout(F.relu(self.conv6(h)), ratio=0.5, train=self.train)
+        h = F.dropout(F.relu(self.conv6(h)), ratio=0.5, train=train)
         h = F.relu(self.conv7(h))
         h = F.relu(self.conv8(h))
         h = F.relu(self.conv9(h))

--- a/examples/cifar10/allconvnet_bn.py
+++ b/examples/cifar10/allconvnet_bn.py
@@ -23,9 +23,8 @@ class AllConvNetBN(chainer.Chain):
                 conv8 = L.Convolution2D(192, 192, 1),
                 conv9 = L.Convolution2D(192, 10, 1),
         )
-        self.train = True
 
-    def __call__(self, x):
+    def __call__(self, x, t=None, train=True):
         h = F.relu(self.conv1(x))
         h = F.relu(self.bn1(self.conv2(h)))
         h = F.relu(self.conv3(h))

--- a/examples/cifar10/cifar10.py
+++ b/examples/cifar10/cifar10.py
@@ -22,7 +22,8 @@ def convert_train_image():
         dir_name = 'cifar-10-batches-py'
         for i in six.moves.range(batches):
             batch_name = dir_name + '/data_batch_' + str(i+1)
-            batch = six.moves.cPickle.load(f.extractfile(batch_name), encoding='latin1')
+            r_data = f.extractfile(batch_name)
+            batch = six.moves.cPickle.load(r_data)
             data[i*batchsize:(i+1)*batchsize] = batch['data'].reshape(batchsize, 3, 32, 32)
             labels[i*batchsize:(i+1)*batchsize] = batch['labels']
     return data, labels
@@ -31,7 +32,8 @@ def convert_test_image():
     with tarfile.open(fname, 'r:gz') as f:
         dir_name = 'cifar-10-batches-py'
         batch_name = dir_name + '/test_batch'
-        batch = six.moves.cPickle.load(f.extractfile(batch_name), encoding='latin1')
+        r_data = f.extractfile(batch_name)
+        batch = six.moves.cPickle.load(r_data)
         data = batch['data'].reshape(batchsize, 3, 32, 32)
         labels = np.asarray(batch['labels']).astype(np.uint8)
     return data, labels
@@ -44,7 +46,7 @@ def load(name='cifar10.pkl'):
 
 
 if __name__ == '__main__':
-    #download()
+    download()
 
     train_data, train_labels = convert_train_image()
     train = {'data': train_data, 

--- a/examples/cifar10/cifar10_siamese_train.py
+++ b/examples/cifar10/cifar10_siamese_train.py
@@ -4,8 +4,6 @@
 import argparse
 import numpy as np
 import chainer
-import chainer.functions as F
-import chainer.links as L
 from chainer import cuda, optimizers
 
 # import dataset script
@@ -19,16 +17,13 @@ from allconvnet import AllConvNet
 parser = argparse.ArgumentParser(description='All Convolutional Network Example on CIFAR-10')
 parser.add_argument('--epoch', '-e', type=int, default=300, help='training epoch (default: 100)')
 parser.add_argument('--batch', '-b', type=int, default=100, help='training batchsize (default: 100)')
-parser.add_argument('--valbatch', '-v', type=int, default=100, help='validation batchsize (default: 100)')
+parser.add_argument('--valbatch', '-v', type=int, default=1000, help='validation batchsize (default: 100)')
 parser.add_argument('--gpu', '-g', type=int, default=-1, help='GPU device #, if you want to use cpu, use -1 (default: -1)')
 args = parser.parse_args()
 
 def cifar_preprocess(data):
     data['data0'] /= 255.
     data['data1'] /= 255.
-
-    data['data0'] = np.expand_dims(data['data0'], 0)
-    data['data1'] = np.expand_dims(data['data1'], 0)
     return data
 
 # Logger setup
@@ -43,6 +38,7 @@ xp = cuda.cupy if args.gpu >= 0 else np
 
 # loading dataset
 dataset = cifar10.load()
+
 dim = dataset['train']['data'][0].size
 N_train = len(dataset['train']['target'])
 N_test = len(dataset['test']['target'])

--- a/examples/cifar10/cifar10_siamese_train.py
+++ b/examples/cifar10/cifar10_siamese_train.py
@@ -12,7 +12,7 @@ from chainer import cuda, optimizers
 import cifar10
 
 # import model network
-from masalachai import Trainer, datafeeders, models
+from masalachai import trainers, datafeeders, models, Logger
 from allconvnet import AllConvNet
 
 # argparse
@@ -24,8 +24,17 @@ parser.add_argument('--gpu', '-g', type=int, default=-1, help='GPU device #, if 
 args = parser.parse_args()
 
 def cifar_preprocess(data):
-    data['data'] /= 255.
+    data['data0'] /= 255.
+    data['data1'] /= 255.
+
+    data['data0'] = np.expand_dims(data['data0'], 0)
+    data['data1'] = np.expand_dims(data['data1'], 0)
     return data
+
+# Logger setup
+logger = Logger('CIFAR SIAMESE',
+        train_log_mode='TRAIN_LOSS_ONLY',
+        test_log_mode='TEST_LOSS_ONLY')
 
 # Configure GPU Device
 if args.gpu >= 0:
@@ -34,16 +43,18 @@ xp = cuda.cupy if args.gpu >= 0 else np
 
 # loading dataset
 dataset = cifar10.load()
+dim = dataset['train']['data'][0].size
+N_train = len(dataset['train']['target'])
+N_test = len(dataset['test']['target'])
+train_data_dict = {'data':dataset['train']['data'].astype(np.float32),
+                   'target':dataset['train']['target'].astype(np.int32)}
+test_data_dict = {'data':dataset['test']['data'].astype(np.float32),
+                  'target':dataset['test']['target'].astype(np.int32)}
+train_data = datafeeders.SiameseFeeder(train_data_dict, batchsize=args.batch)
+test_data = datafeeders.SiameseFeeder(test_data_dict, batchsize=args.valbatch)
 
-train_data_dic = dataset['train']
-train_data_dic['data'] = train_data_dic['data'].astype(np.float32)
-train_data_dic['target'] = train_data_dic['target'].astype(np.int32)
-train_data = datafeeders.SiameseFeeder(data_dict=train_data_dic)
-
-test_data_dic = dataset['test']
-test_data_dic['data'] = test_data_dic['data'].astype(np.float32)
-test_data_dic['target'] = test_data_dic['target'].astype(np.int32)
-test_data = datafeeders.SiameseFeeder(data_dict=test_data_dic)
+train_data.hook_preprocess(cifar_preprocess)
+test_data.hook_preprocess(cifar_preprocess)
 
 
 # Model Setup
@@ -52,15 +63,15 @@ if args.gpu >= 0:
     cuda.get_device(args.gpu).use()
     model.to_gpu()
 
+
 # Opimizer Setup
 optimizer = optimizers.Adam()
 optimizer.setup(model)
 optimizer.add_hook(chainer.optimizer.WeightDecay(0.00002))
 
-trainer = Trainer(optimizer, train_data, test_data, args.gpu, logfile='cifar10_allconvnet.csv')
-trainer.hook(cifar_preprocess)
-trainer.train(args.epoch*train_data['size']/args.batch, 
-              args.batch, 
-              test_interval=train_data['size']/args.batch, 
-              test_nitr=test_data['size']/args.valbatch,
-              test_batchsize=args.valbatch)
+
+trainer = trainers.SupervisedTrainer(optimizer, logger, (train_data,), test_data, args.gpu)
+trainer.train(int(args.epoch*N_train/args.batch), 
+              log_interval=1,
+              test_interval=N_train/args.batch, 
+              test_nitr=N_test/args.valbatch)

--- a/examples/cifar10/cifar10_train.py
+++ b/examples/cifar10/cifar10_train.py
@@ -4,7 +4,6 @@
 import argparse
 import numpy as np
 import chainer
-import chainer.functions as F
 from chainer import cuda, optimizers
 
 # import dataset script
@@ -41,12 +40,13 @@ xp = cuda.cupy if args.gpu >= 0 else np
 
 # loading dataset
 dataset = cifar10.load()
+
 dim = dataset['train']['data'][0].size
 N_train = len(dataset['train']['target'])
 N_test = len(dataset['test']['target'])
-train_data_dict = {'data':dataset['train']['data'].reshape(N_train, dim).astype(np.float32),
+train_data_dict = {'data':dataset['train']['data'].astype(np.float32),
                    'target':dataset['train']['target'].astype(np.int32)}
-test_data_dict = {'data':dataset['test']['data'].reshape(N_test, dim).astype(np.float32),
+test_data_dict = {'data':dataset['test']['data'].astype(np.float32),
                   'target':dataset['test']['target'].astype(np.int32)}
 train_data = DataFeeder(train_data_dict, batchsize=args.batch)
 test_data = DataFeeder(test_data_dict, batchsize=args.valbatch)

--- a/examples/cifar10/cifar10_train.py
+++ b/examples/cifar10/cifar10_train.py
@@ -5,28 +5,34 @@ import argparse
 import numpy as np
 import chainer
 import chainer.functions as F
-import chainer.links as L
 from chainer import cuda, optimizers
 
 # import dataset script
 import cifar10
 
 # import model network
-from masalachai import Trainer
+from masalachai import DataFeeder
+from masalachai import Logger
+from masalachai import trainers
+from masalachai import models
 from allconvnet import AllConvNet
 from allconvnet_bn import AllConvNetBN
 
 # argparse
 parser = argparse.ArgumentParser(description='All Convolutional Network Example on CIFAR-10')
 parser.add_argument('--epoch', '-e', type=int, default=300, help='training epoch (default: 100)')
-parser.add_argument('--batch', '-b', type=int, default=100, help='training batchsize (default: 100)')
-parser.add_argument('--valbatch', '-v', type=int, default=100, help='validation batchsize (default: 100)')
+parser.add_argument('--batch', '-b', type=int, default=500, help='training batchsize (default: 100)')
+parser.add_argument('--valbatch', '-v', type=int, default=1000, help='validation batchsize (default: 100)')
 parser.add_argument('--gpu', '-g', type=int, default=-1, help='GPU device #, if you want to use cpu, use -1 (default: -1)')
 args = parser.parse_args()
+
 
 def cifar_preprocess(data):
     data['data'] /= 255.
     return data
+
+# Logger setup
+logger = Logger('CIFAR10 AllConvNet')
 
 # Configure GPU Device
 if args.gpu >= 0:
@@ -35,32 +41,36 @@ xp = cuda.cupy if args.gpu >= 0 else np
 
 # loading dataset
 dataset = cifar10.load()
+dim = dataset['train']['data'][0].size
+N_train = len(dataset['train']['target'])
+N_test = len(dataset['test']['target'])
+train_data_dict = {'data':dataset['train']['data'].reshape(N_train, dim).astype(np.float32),
+                   'target':dataset['train']['target'].astype(np.int32)}
+test_data_dict = {'data':dataset['test']['data'].reshape(N_test, dim).astype(np.float32),
+                  'target':dataset['test']['target'].astype(np.int32)}
+train_data = DataFeeder(train_data_dict, batchsize=args.batch)
+test_data = DataFeeder(test_data_dict, batchsize=args.valbatch)
 
-train_data = dataset['train']
-train_data['data'] = train_data['data'].astype(np.float32)
-train_data['target'] = train_data['target'].astype(np.int32)
-
-test_data = dataset['test']
-test_data['data'] = test_data['data'].astype(np.float32)
-test_data['target'] = test_data['target'].astype(np.int32)
+train_data.hook_preprocess(cifar_preprocess)
+test_data.hook_preprocess(cifar_preprocess)
 
 
 # Model Setup
-model = L.Classifier(AllConvNet())
-#model = L.Classifier(AllConvNetBN())
+model = models.ClassifierModel(AllConvNet())
+#model = models.ClassifierModel(AllConvNetBN())
 if args.gpu >= 0:
     cuda.get_device(args.gpu).use()
     model.to_gpu()
+
 
 # Opimizer Setup
 optimizer = optimizers.Adam()
 optimizer.setup(model)
 optimizer.add_hook(chainer.optimizer.WeightDecay(0.00002))
 
-trainer = Trainer(optimizer, train_data, test_data, args.gpu, logfile='cifar10_allconvnet.csv')
-trainer.hook(cifar_preprocess)
-trainer.train(args.epoch*train_data['size']/args.batch, 
-              args.batch, 
-              test_interval=train_data['size']/args.batch, 
-              test_nitr=test_data['size']/args.valbatch,
-              test_batchsize=args.valbatch)
+
+trainer = trainers.SupervisedTrainer(optimizer, logger, (train_data,), test_data, args.gpu)
+trainer.train(int(args.epoch*N_train/args.batch), 
+              log_interval=1, 
+              test_interval=N_train/args.batch, 
+              test_nitr=N_test/args.valbatch)

--- a/examples/mnist/mnist_ae.py
+++ b/examples/mnist/mnist_ae.py
@@ -46,8 +46,8 @@ N_train = len(dataset['train']['target'])
 N_test = len(dataset['test']['target'])
 train_data_dict = {'data':dataset['train']['data'].reshape(N_train, dim).astype(np.float32)}
 test_data_dict = {'data':dataset['test']['data'].reshape(N_test, dim).astype(np.float32)}
-train_data = DataFeeder(train_data_dict)
-test_data = DataFeeder(test_data_dict)
+train_data = DataFeeder(train_data_dict, batchsize=args.batch)
+test_data = DataFeeder(test_data_dict, batchsize=args.valbatch)
 
 train_data.hook_preprocess(mnist_preprocess)
 test_data.hook_preprocess(mnist_preprocess)
@@ -70,7 +70,7 @@ optimizer.setup(model)
 
 trainer = trainers.AutoencoderTrainer(optimizer, logger, (train_data,), test_data, args.gpu)
 trainer.train(int(args.epoch*N_train/args.batch), 
-              (args.batch,),
-              test_batchsize=args.valbatch,
-              test_interval=N_train/args.batch)
+              log_interval=1,
+              test_interval=N_train/args.batch,
+              test_nitr=N_test/args.valbatch)
 

--- a/examples/mnist/mnist_classififer.py
+++ b/examples/mnist/mnist_classififer.py
@@ -47,8 +47,8 @@ train_data_dict = {'data':dataset['train']['data'].reshape(N_train, dim).astype(
                    'target':dataset['train']['target'].astype(np.int32)}
 test_data_dict = {'data':dataset['test']['data'].reshape(N_test, dim).astype(np.float32),
                   'target':dataset['test']['target'].astype(np.int32)}
-train_data = DataFeeder(train_data_dict)
-test_data = DataFeeder(test_data_dict)
+train_data = DataFeeder(train_data_dict, batchsize=args.batch)
+test_data = DataFeeder(test_data_dict, batchsize=args.valbatch)
 
 train_data.hook_preprocess(mnist_preprocess)
 test_data.hook_preprocess(mnist_preprocess)
@@ -69,8 +69,7 @@ optimizer.setup(model)
 
 trainer = trainers.SupervisedTrainer(optimizer, logger, (train_data,), test_data, args.gpu)
 trainer.train(int(args.epoch*N_train/args.batch), 
-              (args.batch,),
+              log_interval=1,
               test_interval=N_train/args.batch, 
-              test_nitr=N_test/args.valbatch,
-              test_batchsize=args.valbatch)
+              test_nitr=N_test/args.valbatch)
 

--- a/examples/mnist/mnist_siamese.py
+++ b/examples/mnist/mnist_siamese.py
@@ -52,8 +52,8 @@ train_data_dict = {'data':dataset['train']['data'].astype(np.float32),
                    'target':dataset['train']['target'].astype(np.int32)}
 test_data_dict = {'data':dataset['test']['data'].astype(np.float32),
                   'target':dataset['test']['target'].astype(np.int32)}
-train_data = datafeeders.SiameseFeeder(train_data_dict)
-test_data = datafeeders.SiameseFeeder(test_data_dict)
+train_data = datafeeders.SiameseFeeder(train_data_dict, batchsize=args.batch)
+test_data = datafeeders.SiameseFeeder(test_data_dict, batchsize=args.valbatch)
 
 train_data.hook_preprocess(mnist_preprocess)
 test_data.hook_preprocess(mnist_preprocess)
@@ -74,8 +74,7 @@ optimizer.setup(model)
 
 trainer = trainers.SupervisedTrainer(optimizer, logger, (train_data,), test_data, args.gpu)
 trainer.train(int(args.epoch*N_train/args.batch), 
-              (args.batch,),
+              log_interval=1,
               test_interval=N_train/args.batch, 
-              test_nitr=N_test/args.valbatch,
-              test_batchsize=args.valbatch)
+              test_nitr=N_test/args.valbatch)
 

--- a/examples/mnist/mnist_vat.py
+++ b/examples/mnist/mnist_vat.py
@@ -55,11 +55,12 @@ test_data_dict = {'data':dataset['test']['data'].reshape(N_test, dim).astype(np.
 unlabeled_data_dict = {'data':dataset['train']['data'].reshape(N_train, dim).astype(np.float32)}
 
 # making labeled data
-sample_breakdown = np.array([10, 10, 10, 10, 10, 10, 10, 10, 10, 10])
+s_each = int(args.slabeled / 10)
+sample_breakdown = np.array([s_each for i in range(10)])
 labeled_data_samples = np.zeros((sample_breakdown.sum(), dim), dtype=np.float32)
 labeled_data_labels = np.zeros(sample_breakdown.sum(), dtype=np.int32)
 sp = 0
-for t in range(10):
+for t in range(s_each):
     idx = np.where(dataset['train']['target']==t)[0][:sample_breakdown[t]]
     ep = sp + sample_breakdown[t]
     labeled_data_samples[sp:ep] =  unlabeled_data_dict['data'][idx]

--- a/examples/mnist/mnist_vat.py
+++ b/examples/mnist/mnist_vat.py
@@ -68,9 +68,9 @@ labeled_data_dict = {'data':labeled_data_samples,
                      'target':labeled_data_labels}
 
 
-labeled_data = DataFeeder(labeled_data_dict)
-unlabeled_data = DataFeeder(unlabeled_data_dict)
-test_data = DataFeeder(test_data_dict)
+labeled_data = DataFeeder(labeled_data_dict, batchsize=args.lbatch)
+unlabeled_data = DataFeeder(unlabeled_data_dict, batchsize=args.ubatch)
+test_data = DataFeeder(test_data_dict, batchsize=args.valbatch)
 
 labeled_data.hook_preprocess(mnist_preprocess)
 unlabeled_data.hook_preprocess(mnist_preprocess)

--- a/examples/mnist/mnist_vat.py
+++ b/examples/mnist/mnist_vat.py
@@ -24,6 +24,7 @@ parser.add_argument('--epoch', '-e', type=int, default=10, help='training epoch 
 parser.add_argument('--lbatch', '-l', type=int, default=100, help='labeled training batchsize (default: 100)')
 parser.add_argument('--ubatch', '-u', type=int, default=250, help='unlabeled training batchsize (default: 250)')
 parser.add_argument('--valbatch', '-v', type=int, default=1000, help='validation batchsize (default: 1000)')
+parser.add_argument('--slabeled', '-s', type=int, default=100, help='size of labeled training samples (default: 100)')
 parser.add_argument('--gpu', '-g', type=int, default=-1, help='GPU device #, if you want to use cpu, use -1 (default: -1)')
 args = parser.parse_args()
 

--- a/examples/mnist/mnist_vat.py
+++ b/examples/mnist/mnist_vat.py
@@ -97,8 +97,6 @@ adam_alpha_scheduler = DecayOptimizerScheduler(optimizer, 'alpha', alpha_decay_i
 trainer = trainers.VirtualAdversarialTrainer(optimizer, logger, (labeled_data,unlabeled_data), test_data, args.gpu, eps=0.4, xi=0.001, lam=1.0)
 trainer.add_optimizer_scheduler(adam_alpha_scheduler)
 trainer.train(int(args.epoch*N_train/args.lbatch), 
-              (args.lbatch, args.ubatch),
+              log_interval=1,
               test_interval=100, 
-              test_nitr=N_test/args.valbatch,
-              test_batchsize=args.valbatch)
-
+              test_nitr=10)

--- a/examples/mnist/mnist_vat.py
+++ b/examples/mnist/mnist_vat.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import six
 import argparse
 import numpy as np
 import chainer
@@ -56,11 +57,11 @@ unlabeled_data_dict = {'data':dataset['train']['data'].reshape(N_train, dim).ast
 
 # making labeled data
 s_each = int(args.slabeled / 10)
-sample_breakdown = np.array([s_each for i in range(10)])
+sample_breakdown = np.array([s_each for i in six.moves.range(10)])
 labeled_data_samples = np.zeros((sample_breakdown.sum(), dim), dtype=np.float32)
 labeled_data_labels = np.zeros(sample_breakdown.sum(), dtype=np.int32)
 sp = 0
-for t in range(s_each):
+for t in six.moves.range(s_each):
     idx = np.where(dataset['train']['target']==t)[0][:sample_breakdown[t]]
     ep = sp + sample_breakdown[t]
     labeled_data_samples[sp:ep] =  unlabeled_data_dict['data'][idx]

--- a/examples/mnist/mnist_vat.py
+++ b/examples/mnist/mnist_vat.py
@@ -21,7 +21,7 @@ from mlp import Mlp
 
 # argparse
 parser = argparse.ArgumentParser(description='Supervised Multi Layer Perceptron Example')
-parser.add_argument('--epoch', '-e', type=int, default=10, help='training epoch (default: 10)')
+parser.add_argument('--nitr', '-n', type=int, default=10000, help='number of times of weight update (default: 10000)')
 parser.add_argument('--lbatch', '-l', type=int, default=100, help='labeled training batchsize (default: 100)')
 parser.add_argument('--ubatch', '-u', type=int, default=250, help='unlabeled training batchsize (default: 250)')
 parser.add_argument('--valbatch', '-v', type=int, default=1000, help='validation batchsize (default: 1000)')
@@ -69,7 +69,14 @@ for t in six.moves.range(s_each):
     sp += sample_breakdown[t]
 labeled_data_dict = {'data':labeled_data_samples,
                      'target':labeled_data_labels}
-
+#couldn't fix yuma######
+from sklearn import cross_validation
+lplo = cross_validation.LeavePLabelOut(labels=six.moves.range(N_train), p=args.slabeled)
+labeled_data_samples = unlabeled_data_dict['data'][lpl[0][1]]
+labeled_data_labels = dataset['train']['target'][lpl[0][1]]
+labeled_data_dict = {'data':labeled_data_samples,
+                     'target':labeled_data_labels}
+########################
 
 labeled_data = DataFeeder(labeled_data_dict, batchsize=args.lbatch)
 unlabeled_data = DataFeeder(unlabeled_data_dict, batchsize=args.ubatch)
@@ -99,7 +106,7 @@ adam_alpha_scheduler = DecayOptimizerScheduler(optimizer, 'alpha', alpha_decay_i
 
 trainer = trainers.VirtualAdversarialTrainer(optimizer, logger, (labeled_data,unlabeled_data), test_data, args.gpu, eps=0.4, xi=0.001, lam=1.0)
 trainer.add_optimizer_scheduler(adam_alpha_scheduler)
-trainer.train(int(args.epoch*args.slabeled/args.lbatch), 
+trainer.train(args.nitr, 
               log_interval=1,
               test_interval=100, 
               test_nitr=10)

--- a/examples/mnist/mnist_vat.py
+++ b/examples/mnist/mnist_vat.py
@@ -99,7 +99,7 @@ adam_alpha_scheduler = DecayOptimizerScheduler(optimizer, 'alpha', alpha_decay_i
 
 trainer = trainers.VirtualAdversarialTrainer(optimizer, logger, (labeled_data,unlabeled_data), test_data, args.gpu, eps=0.4, xi=0.001, lam=1.0)
 trainer.add_optimizer_scheduler(adam_alpha_scheduler)
-trainer.train(int(args.epoch*N_train/args.lbatch), 
+trainer.train(int(args.epoch*args.slabeled/args.lbatch), 
               log_interval=1,
               test_interval=100, 
               test_nitr=10)


### PR DESCRIPTION
- DataFeederのインスタンス作成においてバッチサイズの引数が明記されておらず，コマンドライン引数のバッチサイズが反映されていませんでしたので修正しました．
- trainer.train()の引数に未定義の引数が記述されていたので削除の上，test_nitrを修正しました．
- trainer.train()の引数のlog_intervalがタプルで記述され，コンパイルエラーになっていたので修正しました．
- ラベルありサンプルの数をコマンドライン引数slabeledとしてparser.add_argumentに追加しました．
- labeled_dataの作成部において冗長なコードを，先述のコマンドライン引数slabeledを用いて修正しました．
- range()関数がpython2, 3の互換性がない記述になっていたため，sixをインポートして修正しました．
- trainer.train()の引数のtrain_nitrの値はepoch数×1 epochにおける学習回数ですが，今回のラベル付与済み学習画像数はN_trainではなく，slabeledなので変更しました．