### PR TITLE
change a q_rvadv calculation code on trainer/vat.py by using the distance calculater dic.

### DIFF
--- a/masalachai/trainers/vat.py
+++ b/masalachai/trainers/vat.py
@@ -87,7 +87,7 @@ class VirtualAdversarialTrainer(SupervisedTrainer):
             d = vr.grad / xp.sqrt(xp.sum(
                 vr.grad * vr.grad, axis=_axis_tuple(d)[1:], keepdims=True))
         self.r_vadv = chainer.Variable(self.eps * d)
-        q_vadv = chainer.functions.softmax(
-            self.optimizer.target.predictor(x0 + self.r_vadv))
+        q_vadv = self.distance_calculators[self.norm]['activation'](
+                self.optimizer.target.predictor(x0 + self.r_vadv))
         self.lds_loss = self.lam * self.distance_calculators[self.norm]['distance'](p, q_vadv)
         return self.lds_loss


### PR DESCRIPTION
I send PR about the #10 issue. The issue is we should use "distance calculater" to calculate q_rvadv at 90-91 line on trainer/vat.py, so I fixed that.